### PR TITLE
opl-: koa-butterfly

### DIFF
--- a/user/opl-/koa-butterfly.md
+++ b/user/opl-/koa-butterfly.md
@@ -1,0 +1,7 @@
+# Proof
+
+https://github.com/opl-/koa-butterfly
+
+# Description
+
+An MIT licensed router for Koa written from scratch.


### PR DESCRIPTION
An MIT licensed router for Koa written from scratch.